### PR TITLE
add chapter 19-04

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -116,7 +116,7 @@
 - [進階特色](ch19-00-advanced-features.md)
     - [Unsafe Rust](ch19-01-unsafe-rust.md)
     - [進階特徵](ch19-03-advanced-traits.md)
-    - [Advanced Types](ch19-04-advanced-types.md)
+    - [進階型別](ch19-04-advanced-types.md)
     - [Advanced Functions and Closures](ch19-05-advanced-functions-and-closures.md)
     - [Macros](ch19-06-macros.md)
 

--- a/src/ch17-01-what-is-oo.md
+++ b/src/ch17-01-what-is-oo.md
@@ -24,7 +24,7 @@ and `impl` blocks provide methods on structs and enums. Even though structs and
 enums with methods aren’t *called* objects, they provide the same
 functionality, according to the Gang of Four’s definition of objects.
 
-### Encapsulation that Hides Implementation Details
+### 隱藏實作細節的封裝
 
 Another aspect commonly associated with OOP is the idea of *encapsulation*,
 which means that the implementation details of an object aren’t accessible to

--- a/src/ch19-00-advanced-features.md
+++ b/src/ch19-00-advanced-features.md
@@ -6,7 +6,7 @@
 
 * Unsafe Rust：如何選擇捨棄部分 Rust 提供的保證，並自行負責遵守這些保證
 * 進階特徵：關聯型別（associated type）、預設型別參數（default type parameter），完全限定語法（fully qualified syntax），超特徵（supertrait），以及跟特徵相關的新型別模式（newtype pattern）
-* 進階型別：更多有關新型別模式、型別別名（type alias），never 型別，以及動態大小型別
+* 進階型別：更多有關新型別模式、型別別名（type alias），永不型別（never type），以及動態大小型別（dynamically sized type）
 * 進階函式與閉包：函式指標與回傳閉包
 * 巨集（macro）：一種定義「在編譯期定義程式碼的程式碼」之方法
 


### PR DESCRIPTION
[Rendered](https://github.com/rust-tw/book-tw/blob/1e64f74e4ce041c435bf68bd7038f353ad8fab7a/src/ch19-04-advanced-types.md)

本章的專有名詞對照表，若有異議，歡迎提出，

| 原文 | 中文 | 理由 |
| ------- | -------- | ------- |
| bound | 約束 | 沿用前面的翻譯 |
| closure | 閉包 | 沿用前面的翻譯 |
| diverging function | 發散函式 |  |
| dynamically sized type | 動態大小型別 | 沿用前面的翻譯 |
| empty type | 空型別 | |
| metadata | 後設資料 | 詮釋資料？元資料？ |
| never type | 永不型別 | |
| newtype pattern | 新型別模式 | 沿用前面的翻譯 |
| newtype | 新型別 | 沿用前面的翻譯 |
| runtime | 執行期 | 沿用前面的翻譯 |
| trait object | 特徵物件 | 沿用前面的翻譯 |
| trait | 特徵 | 沿用前面的翻譯 |
| type alias| 型別別名 | 沿用前面的翻譯 |
| unsize | 不定大小 | |
