### PR TITLE
add chapter 19-05

### DIFF
--- a/listings/ch19-advanced-features/listing-19-27/src/main.rs
+++ b/listings/ch19-advanced-features/listing-19-27/src/main.rs
@@ -9,5 +9,5 @@ fn do_twice(f: fn(i32) -> i32, arg: i32) -> i32 {
 fn main() {
     let answer = do_twice(add_one, 5);
 
-    println!("The answer is: {}", answer);
+    println!("答案是：{}", answer);
 }

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -117,7 +117,7 @@
     - [Unsafe Rust](ch19-01-unsafe-rust.md)
     - [進階特徵](ch19-03-advanced-traits.md)
     - [進階型別](ch19-04-advanced-types.md)
-    - [Advanced Functions and Closures](ch19-05-advanced-functions-and-closures.md)
+    - [進階函式與閉包](ch19-05-advanced-functions-and-closures.md)
     - [Macros](ch19-06-macros.md)
 
 - [Final Project: Building a Multithreaded Web Server](ch20-00-final-project-a-web-server.md)

--- a/src/ch19-05-advanced-functions-and-closures.md
+++ b/src/ch19-05-advanced-functions-and-closures.md
@@ -1,18 +1,10 @@
-## Advanced Functions and Closures
+## 進階函式與閉包
 
-Next, we’ll explore some advanced features related to functions and
-closures, which include function pointers and returning closures.
+接下來，我們會探索函式與閉包相關的進階特色，包括函式指標和回傳閉包。
 
-### Function Pointers
+### 函式指標
 
-We’ve talked about how to pass closures to functions; you can also pass regular
-functions to functions! This technique is useful when you want to pass a
-function you’ve already defined rather than defining a new closure. Doing this
-with function pointers will allow you to use functions as arguments to other
-functions. Functions coerce to the type `fn` (with a lowercase f), not to be
-confused with the `Fn` closure trait. The `fn` type is called a *function
-pointer*. The syntax for specifying that a parameter is a function pointer is
-similar to that of closures, as shown in Listing 19-27.
+我們已探討過如何將閉包傳遞給函式，其實你還可以將一般的函式傳給函式！當你想要傳遞已經定義好的函式，而不是新的閉包時，就會凸顯這個技巧好用之處。有了函式指標，就可以將函式當作其他函式的引數，而這個作為引數的函式會轉型為 `fn` 型別（小寫的 f），別和閉包特徵的 `Fn` 搞混了。這個 `fn` 型別就稱為「函式指標（function pointer）」。其語法與閉包語法類似，可用於將函式指標作為參數的型別，如範例 19-27 所示。
 
 <span class="filename">檔案名稱：src/main.rs</span>
 
@@ -20,102 +12,67 @@ similar to that of closures, as shown in Listing 19-27.
 {{#rustdoc_include ../listings/ch19-advanced-features/listing-19-27/src/main.rs}}
 ```
 
-<span class="caption">範例 19-27: Using the `fn` type to accept a function
-pointer as an argument</span>
+<span class="caption">範例 19-27：藉由 `fn` 型別接收函式指標引數</span>
 
-This code prints `The answer is: 12`. We specify that the parameter `f` in
-`do_twice` is an `fn` that takes one parameter of type `i32` and returns an
-`i32`. We can then call `f` in the body of `do_twice`. In `main`, we can pass
-the function name `add_one` as the first argument to `do_twice`.
+這段程式碼會印出 `答案是：12`。我們可以指定 `do_twice` 的參數 `f` 是一個需要一個 `i32` 當參數的 `fn`，並會回傳 `i32`。接下來我們在 `do_twice` 內呼叫 `f`。在 `main` 中，我們就可將 `add_one` 函式作為 `do_twice` 第一個引數。
 
-Unlike closures, `fn` is a type rather than a trait, so we specify `fn` as the
-parameter type directly rather than declaring a generic type parameter with one
-of the `Fn` traits as a trait bound.
+和閉包不同的是，`fn` 不是特徵而是一個型別，所以我們可以直接將 `fn` 作為參數型別，而不需要宣告一個以 `Fn` 特徵作為特徵限制的泛型型別參數。
 
-Function pointers implement all three of the closure traits (`Fn`, `FnMut`, and
-`FnOnce`), so you can always pass a function pointer as an argument for a
-function that expects a closure. It’s best to write functions using a generic
-type and one of the closure traits so your functions can accept either
-functions or closures.
 
-An example of where you would want to only accept `fn` and not closures is when
-interfacing with external code that doesn’t have closures: C functions can
-accept functions as arguments, but C doesn’t have closures.
+函式指標將 三個閉包特徵（`Fn`、`FnMut`、`FnOnce`）通通實作了，所以在預期要傳入閉包之處，你一定可以將函式指標作為引數傳進去。最佳的 做法是寫一個同時使用泛型型別和其中一個閉包特徵的函式，這樣無論是函式還是閉包，你的函式全都可以接收。
 
-As an example of where you could use either a closure defined inline or a named
-function, let’s look at a use of `map`. To use the `map` function to turn a
-vector of numbers into a vector of strings, we could use a closure, like this:
+有個你只會想接收 `fn` 但不要閉包例子，就是當你在與外部那些沒有閉包的程式碼打交道的時候，比如 C 可以接收函式作為引數，但 C 並沒有閉包。
+
+讓我們來看一下 `map` 的用法，`map` 就是可以用行內閉包（closure defined inline）或一個命名函式（named function）的例子。欲將數字的 vector 轉換成字串的 vector，我們可以使用閉包，例如：
 
 ```rust
 {{#rustdoc_include ../listings/ch19-advanced-features/no-listing-15-map-closure/src/main.rs:here}}
 ```
 
-Or we could name a function as the argument to `map` instead of the closure,
-like this:
+或者，我們也可以將一個函式作為引數，代替閉包傳入 `map`：
 
 ```rust
 {{#rustdoc_include ../listings/ch19-advanced-features/no-listing-16-map-function/src/main.rs:here}}
 ```
 
-Note that we must use the fully qualified syntax that we talked about earlier
-in the [“Advanced Traits”][advanced-traits]<!-- ignore --> section because
-there are multiple functions available named `to_string`. Here, we’re using the
-`to_string` function defined in the `ToString` trait, which the standard
-library has implemented for any type that implements `Display`.
+請注意，因為有多個可用的函式都叫做 `to_string`，所以我們必須使用先前在[「進階特徵」][進階特徵]一節提及的完全限定語法。這裡，我們使用了在 `ToString` 特徵中定義的 `to_string` 函式，只要有實作 `Display` 的型別，標準函式庫都會提供 `ToString` 的實作。
 
-We have another useful pattern that exploits an implementation detail of tuple
-structs and tuple-struct enum variants. These types use `()` as initializer
-syntax, which looks like a function call. The initializers are actually
-implemented as functions returning an instance that’s constructed from their
-arguments. We can use these initializer functions as function pointers that
-implement the closure traits, which means we can specify the initializer
-functions as arguments for methods that take closures, like so:
+另一個實用模式是深度利用元組結構體和在枚舉變體（enum variant）中的的元組結構體的實作細節。這些型別以 `()` 作為初始化語法，看起來就像函式呼叫。事實上這些初始化以函式來實作，這個函式接收引數來建立並回傳一個實例。我們可以將這些初始化函式當作實作了閉包特徵的函式指標，這就代表我們可以指定初始化函式作為引數，傳給需要閉包的方法，例如：
 
 ```rust
 {{#rustdoc_include ../listings/ch19-advanced-features/no-listing-17-map-initializer/src/main.rs:here}}
 ```
+這裡，我們對一個範圍呼叫 `map`，並用每個 `u32` 值，透過 `Status::Value` 的初始化函式來建立 `Status::Value` 的實例。有些人更喜歡上述的作法，但有人偏好閉包。這兩者的編譯結果相同，所以選一個你覺得清晰的風格吧。
 
-Here we create `Status::Value` instances using each `u32` value in the range
-that `map` is called on by using the initializer function of `Status::Value`.
-Some people prefer this style, and some people prefer to use closures. They
-compile to the same code, so use whichever style is clearer to you.
+### 回傳閉包
 
-### Returning Closures
+閉包是用特徵來表示，言下之意是你不能直接回傳一個閉包。大多數的情況，當你想回傳一個特徵時，可以改回傳有實作該特徵的具體型別。但你並無法對閉包這樣做，因為它們根本沒有可供回傳的具體型別，比方說不允許你使用 `fn` 函式指標作為回傳型別。
 
-Closures are represented by traits, which means you can’t return closures
-directly. In most cases where you might want to return a trait, you can instead
-use the concrete type that implements the trait as the return value of the
-function. But you can’t do that with closures because they don’t have a
-concrete type that is returnable; you’re not allowed to use the function
-pointer `fn` as a return type, for example.
-
-The following code tries to return a closure directly, but it won’t compile:
+接下來的程式碼嘗試直接回傳一個閉包，但它無法編譯：
 
 ```rust,ignore,does_not_compile
 {{#rustdoc_include ../listings/ch19-advanced-features/no-listing-18-returns-closure/src/lib.rs}}
 ```
 
-The compiler error is as follows:
+編譯錯誤如下：
 
 ```console
 {{#include ../listings/ch19-advanced-features/no-listing-18-returns-closure/output.txt}}
 ```
 
-The error references the `Sized` trait again! Rust doesn’t know how much space
-it will need to store the closure. We saw a solution to this problem earlier.
-We can use a trait object:
+這個錯誤再度指出 `Sized` 特徵！Rust 不知道我們需要多少空間儲存這個閉包，我們之前看過這類問題的解法。可以使用特徵物件（trait object）：
 
 ```rust
 {{#rustdoc_include ../listings/ch19-advanced-features/no-listing-19-returns-closure-trait-object/src/lib.rs}}
 ```
 
-This code will compile just fine. For more about trait objects, refer to the
-section [“允許不同型別數值的特徵物件”][using-trait-objects-that-allow-for-values-of-different-types]<!--
-ignore --> in Chapter 17.
+這段程式碼恰巧能通過編譯。欲知更多特徵物件相關資訊，請查閱第十七章[「允許不同型別數值的特徵物件」][允許不同型別數值的特徵物件]部分。
 
-Next, let’s look at macros!
+接下來，一起來關注巨集吧！
 
-[advanced-traits]:
-ch19-03-advanced-traits.html#advanced-traits
-[using-trait-objects-that-allow-for-values-of-different-types]:
-ch17-02-trait-objects.html#using-trait-objects-that-allow-for-values-of-different-types
+[進階特徵]: ch19-03-advanced-traits.html#進階特徵
+[允許不同型別數值的特徵物件]: ch17-02-trait-objects.html#允許不同型別數值的特徵物件
+
+> - translators: [Weihang Lo <me@weihanglo.tw>]
+> - commit: [d44317c](https://github.com/rust-lang/book/blob/d44317c3122b44fb713aba66cc295dee3453b24b/src/ch19-05-advanced-functions-and-closures.md)
+> - updated: 2020-09-17


### PR DESCRIPTION
[Rendered](https://github.com/rust-tw/book-tw/blob/bda81a07bffff01e079e85a23026ed6857396dbb/src/ch19-05-advanced-functions-and-closures.md)

本章的專有名詞對照表，若有異議，歡迎提出，

| 原文 | 中文 | 理由 |
| ------- | -------- | ------- |
| enum variant | 枚舉變體 | 延續翻譯 |
| function pointer | 函式指標 | 直觀翻譯 |
| inline closure, closure defined inline | 行內閉包 | |
| named function | 命名函式 | |
| trait object | 特徵物件 | 延續翻譯 |
