### PR TITLE
Feat/ch 19 06

### DIFF
--- a/listings/ch19-advanced-features/listing-19-31/hello_macro/src/main.rs
+++ b/listings/ch19-advanced-features/listing-19-31/hello_macro/src/main.rs
@@ -4,7 +4,7 @@ struct Pancakes;
 
 impl HelloMacro for Pancakes {
     fn hello_macro() {
-        println!("Hello, Macro! My name is Pancakes!");
+        println!("你好，巨集！我叫作鬆餅！");
     }
 }
 

--- a/listings/ch19-advanced-features/listing-19-33/hello_macro/hello_macro_derive/src/lib.rs
+++ b/listings/ch19-advanced-features/listing-19-33/hello_macro/hello_macro_derive/src/lib.rs
@@ -20,7 +20,7 @@ fn impl_hello_macro(ast: &syn::DeriveInput) -> TokenStream {
     let gen = quote! {
         impl HelloMacro for #name {
             fn hello_macro() {
-                println!("Hello, Macro! My name is {}!", stringify!(#name));
+                println!("你好，巨集，我叫作{}！", stringify!(#name));
             }
         }
     };

--- a/listings/ch19-advanced-features/listing-19-33/hello_macro/src/main.rs
+++ b/listings/ch19-advanced-features/listing-19-33/hello_macro/src/main.rs
@@ -4,7 +4,7 @@ struct Pancakes;
 
 impl HelloMacro for Pancakes {
     fn hello_macro() {
-        println!("Hello, Macro! My name is Pancakes!");
+        println!("你好，巨集！我叫作鬆餅！");
     }
 }
 

--- a/listings/ch19-advanced-features/no-listing-20-impl-hellomacro-for-pancakes/pancakes/src/main.rs
+++ b/listings/ch19-advanced-features/no-listing-20-impl-hellomacro-for-pancakes/pancakes/src/main.rs
@@ -4,7 +4,7 @@ struct Pancakes;
 
 impl HelloMacro for Pancakes {
     fn hello_macro() {
-        println!("Hello, Macro! My name is Pancakes!");
+        println!("你好，巨集！我叫作鬆餅！");
     }
 }
 

--- a/listings/ch19-advanced-features/no-listing-21-pancakes/hello_macro/hello_macro_derive/src/lib.rs
+++ b/listings/ch19-advanced-features/no-listing-21-pancakes/hello_macro/hello_macro_derive/src/lib.rs
@@ -19,7 +19,7 @@ fn impl_hello_macro(ast: &syn::DeriveInput) -> TokenStream {
     let gen = quote! {
         impl HelloMacro for #name {
             fn hello_macro() {
-                println!("Hello, Macro! My name is {}!", stringify!(#name));
+                println!("你好，巨集，我叫作{}！", stringify!(#name));
             }
         }
     };

--- a/listings/ch19-advanced-features/no-listing-21-pancakes/hello_macro/src/main.rs
+++ b/listings/ch19-advanced-features/no-listing-21-pancakes/hello_macro/src/main.rs
@@ -4,7 +4,7 @@ struct Pancakes;
 
 impl HelloMacro for Pancakes {
     fn hello_macro() {
-        println!("Hello, Macro! My name is Pancakes!");
+        println!("你好，巨集！我叫作鬆餅！");
     }
 }
 

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -118,7 +118,7 @@
     - [進階特徵](ch19-03-advanced-traits.md)
     - [進階型別](ch19-04-advanced-types.md)
     - [進階函式與閉包](ch19-05-advanced-functions-and-closures.md)
-    - [Macros](ch19-06-macros.md)
+    - [巨集](ch19-06-macros.md)
 
 - [Final Project: Building a Multithreaded Web Server](ch20-00-final-project-a-web-server.md)
     - [Building a Single-Threaded Web Server](ch20-01-single-threaded.md)

--- a/src/ch19-03-advanced-traits.md
+++ b/src/ch19-03-advanced-traits.md
@@ -138,7 +138,7 @@ Rust 並沒有限制不同特徵之間不能有同名的方法，也沒有阻止
 
 因為 `fly` 方法有個 `self` 參數，所以我們若有兩個*型別*都實作了同個特徵，Rust 可以透過 `self` 的型別理出該用哪個特徵的實作。
 
-然而，當特徵上的關聯函式（associated function）沒有 `self` 參數時，當同個範圍下的兩個型別都實作同個特徵，除非使用*完全限定語法（fully qualified syntax）*，否則 Rusti 無法推斷你指涉哪個型別。舉例來說，範例 19-19 的 `Animal` 特徵有個對 `Dog` 實作 `Animal` 所得的關聯函式 `baby_name`，同時也有直接在 `Dog` 上實作的關聯函式 `baby_name`。
+然而，當特徵上的關聯函式（associated function）沒有 `self` 參數時，當同個作用域下的兩個型別都實作同個特徵，除非使用「完全限定語法（fully qualified syntax）」，否則 Rusti 無法推斷你指涉哪個型別。舉例來說，範例 19-19 的 `Animal` 特徵有個對 `Dog` 實作 `Animal` 所得的關聯函式 `baby_name`，同時也有直接在 `Dog` 上實作的關聯函式 `baby_name`。
 
 <span class="filename">檔案名稱：src/main.rs</span>
 
@@ -220,7 +220,7 @@ Rust 並沒有限制不同特徵之間不能有同名的方法，也沒有阻止
 
 <span class="caption">範例 19-22: 實作要求 `Display` 功能的 `OutlinePrint` 特徵</span>
 
-因為我們已指明 `OutlinePrint` 需要 `Display` 特徵，且只要有實作 `Display` 的型別都會自動實作 `to_string` 這個函式，所以我們可以使用 `to_string`。若我們嘗試使用 `to_string` 但並沒有在該特徵後加上冒號並指明 `Display`，會得到一個錯誤，告訴我們在當前範圍下的 `&Self` 型別找不到名為 `to_string` 函數。
+因為我們已指明 `OutlinePrint` 需要 `Display` 特徵，且只要有實作 `Display` 的型別都會自動實作 `to_string` 這個函式，所以我們可以使用 `to_string`。若我們嘗試使用 `to_string` 但並沒有在該特徵後加上冒號並指明 `Display`，會得到一個錯誤，告訴我們在當前作用域下的 `&Self` 型別找不到名為 `to_string` 函數。
 
 我們嘗試看看在一個沒有實作 `Display` 的型別上實作 `OutlinePrint`（如 `Point` 結構體）會發生什麼事：
 

--- a/src/ch19-06-macros.md
+++ b/src/ch19-06-macros.md
@@ -1,79 +1,38 @@
-## Macros
+## 巨集
 
-We’ve used macros like `println!` throughout this book, but we haven’t fully
-explored what a macro is and how it works. The term *macro* refers to a family
-of features in Rust: *declarative* macros with `macro_rules!` and three kinds
-of *procedural* macros:
+在本書中，我們到處使用像 `println!` 這類的巨集（macro），但尚未完全探索巨集究竟是何物，以及該如何駕馭。**巨集**指的是一整家族的 Rust 功能集合：使用 `macro_rules!` 的**宣告式（declarative）巨集**，以及另外三種**程序式（procedural）巨集**：
 
-* Custom `#[derive]` macros that specify code added with the `derive` attribute
-  used on structs and enums
-* Attribute-like macros that define custom attributes usable on any item
-* Function-like macros that look like function calls but operate on the tokens
-  specified as their argument
+* 客製化 `#[derive]` 巨集，可以將指定的程式碼加在使用 `derive` 屬性的結構體和枚舉
+* 類屬性巨集，定義客製化，可以用在任何項目（item）的屬性
+* 類函式巨集，看起來在呼叫函式但實際上將標記（token）當作引數來處理
 
-We’ll talk about each of these in turn, but first, let’s look at why we even
-need macros when we already have functions.
+我們將會按照順序聊聊每種巨集，但首先，來看看為什麼我們已經有了函式，仍需要巨集呢？
 
-### The Difference Between Macros and Functions
+### 巨集與函式的差異
 
-Fundamentally, macros are a way of writing code that writes other code, which
-is known as *metaprogramming*. In Appendix C, we discuss the `derive`
-attribute, which generates an implementation of various traits for you. We’ve
-also used the `println!` and `vec!` macros throughout the book. All of these
-macros *expand* to produce more code than the code you’ve written manually.
+基本上，巨集是一種透過寫程式碼來產生其他程式碼的手段，又稱作**超程式設計（metaprogramming）**。像是在附錄 C，我們探討的 `derive` 屬性，這個屬性會替你產生多種特徵的實作。還有在整本書中到處使用 `println!` 和 `vec!` 兩巨集。以上這些巨集都會**展開**來，產生比你自己手寫的還要多的程式碼。
 
-Metaprogramming is useful for reducing the amount of code you have to write and
-maintain, which is also one of the roles of functions. However, macros have
-some additional powers that functions don’t.
+超程式設計對減少撰寫和維護的程式碼量非常有幫助，這和函式扮演的角色相同，然而，巨集具有函式沒有的特殊本事。
 
-A function signature must declare the number and type of parameters the
-function has. Macros, on the other hand, can take a variable number of
-parameters: we can call `println!("hello")` with one argument or
-`println!("hello {}", name)` with two arguments. Also, macros are expanded
-before the compiler interprets the meaning of the code, so a macro can, for
-example, implement a trait on a given type. A function can’t, because it gets
-called at runtime and a trait needs to be implemented at compile time.
+一個函式簽名必須宣告該函式需要的參數型別與數量。反觀巨集可以接收變動數量的參數：我們可以用一個參數呼叫 `println!("hello")` ，也可以是兩個參數的 `println!("hello {}", name)`。另外，巨集會在編譯器開始翻譯程式碼的意義之前展開。例如可以使用巨集實作一個特徵。這種事函式便無法做到，因為函式會在執行期呼叫，而特徵需要在編譯期就實作。
 
-The downside to implementing a macro instead of a function is that macro
-definitions are more complex than function definitions because you’re writing
-Rust code that writes Rust code. Due to this indirection, macro definitions are
-generally more difficult to read, understand, and maintain than function
-definitions.
+選擇實作巨集而不用函式也有缺點，巨集的定義比函式更加複雜，因為你是在寫寫 Rust 程式碼的 Rust 程式碼。就是因為這種間接迂迴的關係，一般情況下，相較於函式來說巨集的定義都更加難以閱讀、理解與維護。
 
-Another important difference between macros and functions is that you must
-define macros or bring them into scope *before* you call them in a file, as
-opposed to functions you can define anywhere and call anywhere.
+另一個巨集和函式之間的重要的的差異，在一個檔案中想呼叫巨集，必須在作用域（scope）內定義或是將巨集帶到這個作用域，而反過來函式可以在任何地方定義與呼叫。
 
-### Declarative Macros with `macro_rules!` for General Metaprogramming
+### 使用 `macro_rules!` 宣告式巨集做普通的超程式設計
 
-The most widely used form of macros in Rust is *declarative macros*. These are
-also sometimes referred to as “macros by example,” “`macro_rules!` macros,” or
-just plain “macros.” At their core, declarative macros allow you to write
-something similar to a Rust `match` expression. As discussed in Chapter 6,
-`match` expressions are control structures that take an expression, compare the
-resulting value of the expression to patterns, and then run the code associated
-with the matching pattern. Macros also compare a value to patterns that are
-associated with particular code: in this situation, the value is the literal
-Rust source code passed to the macro; the patterns are compared with the
-structure of that source code; and the code associated with each pattern, when
-matched, replaces the code passed to the macro. This all happens during
-compilation.
+Rust 中最廣泛使用的巨集形式非**宣告式巨集**莫屬。這種巨集有時也稱為「巨集為例（macros by example）」、「`macro_rules!`」，或是直白的「巨集」。宣告式巨集的核心就是賦予你寫些類似 Rust `match` 表達式的東西。在第六章我們聊了 `match` 表達式是一種流程控制結構，會拿一個表達式，將其結果值與其他模式作比較，並執行匹配模式對應的程式碼。巨集同樣會拿一個值，與模式相比較，而這個模式又與特定程式碼相關聯：這種情況會是，傳入巨集的值就是一字一字刻出來 Rust 原始碼，而所謂模式則是比較原始碼的結構，當原始碼與模式相匹配，就會帶入與模式關聯的這段特定程式碼，取代原先傳入巨集的原始碼。這些都發生在編譯的期間。
 
-To define a macro, you use the `macro_rules!` construct. Let’s explore how to
-use `macro_rules!` by looking at how the `vec!` macro is defined. Chapter 8
-covered how we can use the `vec!` macro to create a new vector with particular
-values. For example, the following macro creates a new vector containing three
-integers:
+你可以透過 `macro_rules!` 定義一個巨集。讓我們藉著閱讀 `vec!` 的定義來探索如何使用 `macro_rules!`。第八章我們介紹了如何使用 `vec!` 巨集來建立含有特定值的 vector。例如，下面的巨集會建立帶著三個整數的新 vector：
 
 ```rust
 let v: Vec<u32> = vec![1, 2, 3];
 ```
 
-We could also use the `vec!` macro to make a vector of two integers or a vector
-of five string slices. We wouldn’t be able to use a function to do the same
-because we wouldn’t know the number or type of values up front.
+我們也可利用 `vec!` 巨集產生兩個整數的 vector 或是五個字串的 slice。因為不能預先得知這些值的數量，所以我們無法透過函式做到這件事。
 
-Listing 19-28 shows a slightly simplified definition of the `vec!` macro.
+範例 19-28 展示了稍微簡化過的 `vec!` 巨集定義。
 
 <span class="filename">檔案名稱：src/lib.rs</span>
 
@@ -81,55 +40,27 @@ Listing 19-28 shows a slightly simplified definition of the `vec!` macro.
 {{#rustdoc_include ../listings/ch19-advanced-features/listing-19-28/src/lib.rs}}
 ```
 
-<span class="caption">範例 19-28: A simplified version of the `vec!` macro
-definition</span>
+<span class="caption">範例 19-28：`vec!` 巨集定義簡化版</span>
 
-> Note: The actual definition of the `vec!` macro in the standard library
-> includes code to preallocate the correct amount of memory up front. That code
-> is an optimization that we don’t include here to make the example simpler.
+> 注意：在標準函式庫中真實的 `vec!` 巨集定義有預先配置正確記憶體用量的程式碼，因為這段程式碼是一種最佳化手段，為了簡化範例，並無將之包含其中。
 
-The `#[macro_export]` annotation indicates that this macro should be made
-available whenever the crate in which the macro is defined is brought into
-scope. Without this annotation, the macro can’t be brought into scope.
+這個 `#[macro_export]` 標註（annotation）用來指明只要這個 crate 有在程式碼可見作用域中，就可以使用該巨集。若沒有這個標註，巨集就不能帶入該作用域內。
 
-We then start the macro definition with `macro_rules!` and the name of the
-macro we’re defining *without* the exclamation mark. The name, in this case
-`vec`, is followed by curly brackets denoting the body of the macro definition.
+我們的巨集定義從 `macro_rules!` 和我們欲定義的巨集名稱**去除**驚嘆號開始。這個名稱，在我們例子裡是 `vec`，的後面接著花括號表示巨集定義的本體。
 
-The structure in the `vec!` body is similar to the structure of a `match`
-expression. Here we have one arm with the pattern `( $( $x:expr ),* )`,
-followed by `=>` and the block of code associated with this pattern. If the
-pattern matches, the associated block of code will be emitted. Given that this
-is the only pattern in this macro, there is only one valid way to match; any
-other pattern will result in an error. More complex macros will have more than
-one arm.
+這個 `vec!` 本體的結構和 `match` 表達式的結構相似。這裡我們有一個 match 分支，帶著模式 `( $( $x:expr ),* )`，並接著 `=>` 後面與該模式相關聯的程式碼區塊。這個分支是此巨集唯一一個模式，所以只有一個合法匹配方式；任何其他模式都會產生錯誤。更複雜的巨集會有多於一個分支。
 
-Valid pattern syntax in macro definitions is different than the pattern syntax
-covered in Chapter 18 because macro patterns are matched against Rust code
-structure rather than values. Let’s walk through what the pattern pieces in
-Listing 19-28 mean; for the full macro pattern syntax, see [the reference].
+合法的巨集定義模式語法和在第十八章的模式語法並不相同，巨集的模式並不跟值比較，而是與 Rust 程式碼的結構相互匹配。在範例 19-28 我們會走過一次這些模式的意義，至於完整的巨集模式語法，請閱讀[參考手冊]。
 
-[the reference]: ../reference/macros-by-example.html
+[參考手冊]: ../reference/macros-by-example.html
 
-First, a set of parentheses encompasses the whole pattern. A dollar sign (`$`)
-is next, followed by a set of parentheses that captures values that match the
-pattern within the parentheses for use in the replacement code. Within `$()` is
-`$x:expr`, which matches any Rust expression and gives the expression the name
-`$x`.
+首先，一對圓括號包圍整個模式。在括號後面的錢字號（`$`）捕獲了在括號內匹配該模式的值，用來取代該段程式碼。在 `$()` 內的 `$x:expr` 會匹配任意 Rust 表達式，並給這個表達式一個 `$x` 名。
 
-The comma following `$()` indicates that a literal comma separator character
-could optionally appear after the code that matches the code in `$()`. The `*`
-specifies that the pattern matches zero or more of whatever precedes the `*`.
+在 `$()` 後的逗號代表字面上的逗號分隔，可以選擇性地在匹配 `$()` 內的程式碼後出現。而 `*` 這指明，這個模式可以匹配零至多個在 `*` 之前的東西。
 
-When we call this macro with `vec![1, 2, 3];`, the `$x` pattern matches three
-times with the three expressions `1`, `2`, and `3`.
+當我們的以 `vec![1, 2, 3]` 呼叫這個巨集，`$x` 模式會匹配到三次，分別為 `1`、`2` 和 `3` 三個表達式。
 
-Now let’s look at the pattern in the body of the code associated with this arm:
-`temp_vec.push()` within `$()*` is generated for each part that matches `$()`
-in the pattern zero or more times depending on how many times the pattern
-matches. The `$x` is replaced with each expression matched. When we call this
-macro with `vec![1, 2, 3];`, the code generated that replaces this macro call
-will be the following:
+現在來看看這個模式分支的主體程式碼：在 `$()*` 內的 `temp_vec.push()` 會根據 `$()` 模式匹配了幾次而產生幾次。這個 `$x` 會被每個匹配的表達式取代。當我們使用 `vec![1, 2, 3]` 呼叫巨集時，這個取代巨集呼叫而產生出來的程式碼會是：
 
 ```rust,ignore
 {
@@ -141,36 +72,19 @@ will be the following:
 }
 ```
 
-We’ve defined a macro that can take any number of arguments of any type and can
-generate code to create a vector containing the specified elements.
+我們定義了一個巨集，接收任意數量任意型別的引數，並產生建立一個包含指定元素的 vector 的程式碼。
 
-There are some strange edge cases with `macro_rules!`. In the future, Rust will
-have a second kind of declarative macro that will work in a similar fashion but
-fix some of these edge cases. After that update, `macro_rules!` will be
-effectively deprecated. With this in mind, as well as the fact that most Rust
-programmers will *use* macros more than *write* macros, we won’t discuss
-`macro_rules!` any further. To learn more about how to write macros, consult
-the online documentation or other resources, such as [“The Little Book of Rust
-Macros”][tlborm].
+有鑑於 `macro_rules!` 仍有些詭異的邊界情況（edge case），未來 Rust 會有第二類宣告式巨集，會具有相似的工作流程，但會修復這些邊界情況。在該更新到來過後，`macro_rules!` 會即期棄用（deprecate）。考量到這點，加上以事實來說大多數 Rust 程式設計師**使用**巨集多過**撰寫**巨集，所以 `macro_rules!` 相關討論就此打住，想理解更多有關撰寫巨集之事，可查閱線上文件或其他資源，例如[「The Little Book of Rust Macros」][tlborm]。
 
 [tlborm]: https://danielkeep.github.io/tlborm/book/index.html
 
-### Procedural Macros for Generating Code from Attributes
+### 使用程序式巨集從屬性產生程式碼
 
-The second form of macros is *procedural macros*, which act more like functions
-(and are a type of procedure). Procedural macros accept some code as an input,
-operate on that code, and produce some code as an output rather than matching
-against patterns and replacing the code with other code as declarative macros
-do.
+第二種巨集形式是**程序式巨集**，其行為更像是函式（也是一種程序）。程序式巨集接受一些程式碼作為輸入，操作這些程式碼，然後輸出一些程式碼。和宣告式巨集去匹配模式和取代程式碼的方式不同。
 
-The three kinds of procedural macros (custom derive, attribute-like, and
-function-like) all work in a similar fashion.
+三種程序式巨集（客製化 derive，類屬性、類函式）都有著相近的工作方式。
 
-When creating procedural macros, the definitions must reside in their own crate
-with a special crate type. This is for complex technical reasons that we hope
-to eliminate in the future. Using procedural macros looks like the code in
-Listing 19-29, where `some_attribute` is a placeholder for using a specific
-macro.
+當建立一個程序式巨集時，該巨集必須放置在自己特殊的一種 crate 中。會這種是因為一些複雜的技術問題，我們希望在未來消弭這個情況。使用程序式巨集看起來就像範例 19-29，其中 `some_attribute` 是一個用來代表特定巨集的佔位符。
 
 <span class="filename">檔案名稱：src/lib.rs</span>
 
@@ -182,33 +96,15 @@ pub fn some_name(input: TokenStream) -> TokenStream {
 }
 ```
 
-<span class="caption">範例 19-29: An example of using a procedural
-macro</span>
+<span class="caption">範例 19-29：使用程序式巨集</span>
 
-The function that defines a procedural macro takes a `TokenStream` as an input
-and produces a `TokenStream` as an output. The `TokenStream` type is defined by
-the `proc_macro` crate that is included with Rust and represents a sequence of
-tokens. This is the core of the macro: the source code that the macro is
-operating on makes up the input `TokenStream`, and the code the macro produces
-is the output `TokenStream`. The function also has an attribute attached to it
-that specifies which kind of procedural macro we’re creating. We can have
-multiple kinds of procedural macros in the same crate.
+這個函式定義一個程序式巨集，接受輸入 `TokenStream`，並輸入 `TokenStream`。`TokenStream` 型別定義在 `proc_macro` crate 中，這個 crate 包含在 Rust 中，可以表示一連串的標記，這就是巨集的核心：巨集替來自輸入的 `TokenStream` 搽脂抹粉，而巨集產生的程式碼就是輸出的 `TokenStream`。上面例子中這個函式附加了一個屬性，指定我們要產生哪個程序式巨集。在同一個 crate 中我們可以使用多個不同的程序式巨集。
 
-Let’s look at the different kinds of procedural macros. We’ll start with a
-custom derive macro and then explain the small dissimilarities that make the
-other forms different.
+我們來看不同的程序式巨集吧。就從客製化 derive 巨集開始，逐步介紹它與其他種類巨集的細部差異。
 
-### How to Write a Custom `derive` Macro
+### 如何撰寫客製化的 `derive` 巨集
 
-Let’s create a crate named `hello_macro` that defines a trait named
-`HelloMacro` with one associated function named `hello_macro`. Rather than
-making our crate users implement the `HelloMacro` trait for each of their
-types, we’ll provide a procedural macro so users can annotate their type with
-`#[derive(HelloMacro)]` to get a default implementation of the `hello_macro`
-function. The default implementation will print `Hello, Macro! My name is
-TypeName!` where `TypeName` is the name of the type on which this trait has
-been defined. In other words, we’ll write a crate that enables another
-programmer to write code like Listing 19-30 using our crate.
+我們建立一個 `hello_macro` crate，並定義 `HelloMacro` 特徵與它的 `hello_macro` 關聯函式。我們提供一個程序式巨集，讓使用者透過 `#[derive(HelloMacro)]` 標註它們的型別，來獲得預設的 `hello_macro` 函式的實作，而不需要使用者替每個型別手動實作 `HelloMacro` 特徵。這個預設的函式實作會印出 `你好，巨集，我叫作型別名稱！`，其中 `型別名稱` 是實作特徵那個型別的名字。換句話說，就是我們會寫出一個 crate，讓其他程式設計師用我們的 crate，以範例 19-30 的方式來寫程式。
 
 <span class="filename">檔案名稱：src/main.rs</span>
 
@@ -216,17 +112,15 @@ programmer to write code like Listing 19-30 using our crate.
 {{#rustdoc_include ../listings/ch19-advanced-features/listing-19-30/src/main.rs}}
 ```
 
-<span class="caption">範例 19-30: The code a user of our crate will be able
-to write when using our procedural macro</span>
+<span class="caption">範例 19-30：使用者使用我們的程序式巨集時，能夠寫出的程式碼</span>
 
-This code will print `Hello, Macro! My name is Pancakes!` when we’re done. The
-first step is to make a new library crate, like this:
+當我們完成後，這段程式碼會印出 `你好，巨集！我叫作鬆餅！`。第一步，先建立一個新的函式庫 crate：
 
 ```console
 $ cargo new hello_macro --lib
 ```
 
-Next, we’ll define the `HelloMacro` trait and its associated function:
+接下來，我們會定義 `HelloMacro` 特徵與它的關聯函式：
 
 <span class="filename">檔案名稱：src/lib.rs</span>
 
@@ -234,48 +128,25 @@ Next, we’ll define the `HelloMacro` trait and its associated function:
 {{#rustdoc_include ../listings/ch19-advanced-features/no-listing-20-impl-hellomacro-for-pancakes/hello_macro/src/lib.rs}}
 ```
 
-We have a trait and its function. At this point, our crate user could implement
-the trait to achieve the desired functionality, like so:
+我們有個特徵及其函式。至此，我們的 crate 使用者可以實作此特徵來達成他們想要的功能，例如：
 
 ```rust,ignore
 {{#rustdoc_include ../listings/ch19-advanced-features/no-listing-20-impl-hellomacro-for-pancakes/pancakes/src/main.rs}}
 ```
 
-However, they would need to write the implementation block for each type they
-wanted to use with `hello_macro`; we want to spare them from having to do this
-work.
+然而，使用者必須自行替每個想使用 `hello_macro` 的型別分別撰寫實作區塊，我們想節約這些重複工作。
 
-Additionally, we can’t yet provide the `hello_macro` function with default
-implementation that will print the name of the type the trait is implemented
-on: Rust doesn’t have reflection capabilities, so it can’t look up the type’s
-name at runtime. We need a macro to generate code at compile time.
+另外，我們尚未提供 `hello_macro` 函式的預設實作，這個預設實作將會印出實作該特徵的型別名稱，但 Rust 並沒有反射（reflection）這種功能，所以無法在執行期檢查型別，因此我們需要一個巨集在編譯期產生程式碼。
 
-The next step is to define the procedural macro. At the time of this writing,
-procedural macros need to be in their own crate. Eventually, this restriction
-might be lifted. The convention for structuring crates and macro crates is as
-follows: for a crate named `foo`, a custom derive procedural macro crate is
-called `foo_derive`. Let’s start a new crate called `hello_macro_derive` inside
-our `hello_macro` project:
+下一步是定義程序式巨集。在我們寫此章時，程序式巨集必須在自己的 crate 中定義，最終這個限制會解除。組織安排 crate 和巨集 crate 的慣例如下：有一個 crate `foo` 和一個客製化 derive 程序式巨集 crate `foo_derive`，讓我們在 `hello_macro` 專案中建立一個新的 crate `hello_macro_derive`：
 
 ```console
 $ cargo new hello_macro_derive --lib
 ```
 
-Our two crates are tightly related, so we create the procedural macro crate
-within the directory of our `hello_macro` crate. If we change the trait
-definition in `hello_macro`, we’ll have to change the implementation of the
-procedural macro in `hello_macro_derive` as well. The two crates will need to
-be published separately, and programmers using these crates will need to add
-both as dependencies and bring them both into scope. We could instead have the
-`hello_macro` crate use `hello_macro_derive` as a dependency and re-export the
-procedural macro code. However, the way we’ve structured the project makes it
-possible for programmers to use `hello_macro` even if they don’t want the
-`derive` functionality.
+由於我們的兩個 crate 高度關聯，所以會在 `hello_macro` crate 的目錄中建立一個程序式巨集 crate。若我們改變 `hello_macro` 中定義的特徵，就必須同時改變 `hello_macro_derive` 中的程序式巨集。這兩個 crate 必須各自發佈，且若程式設計師想要使用這些 crate，則必須將兩者都加入為依賴（dependency），並將之帶入作用域。當然，我們也可以讓 `hello_macro` 將 `hello_macro_derive` 作為一個依賴並重新導出（re-export）該程序式巨集。然而，我們這樣組織專案的方式就是想提供當程式設計師不想要 `derive` 功能時，也可以直接使用 `hello_macro`。
 
-We need to declare the `hello_macro_derive` crate as a procedural macro crate.
-We’ll also need functionality from the `syn` and `quote` crates, as you’ll see
-in a moment, so we need to add them as dependencies. Add the following to the
-*Cargo.toml* file for `hello_macro_derive`:
+我們必須宣告 `hello_macro_derive` 為一個程序式巨集 crate。我們同時需要等會兒就會遇到的 `syn` 和 `quote` 這些 crate 的功能，所以先將他們加至依賴。至此，`hello_macro_derive` 的 *Cargo.toml* 會加入以下的程式碼：
 
 <span class="filename">檔案名稱：hello_macro_derive/Cargo.toml</span>
 
@@ -283,9 +154,7 @@ in a moment, so we need to add them as dependencies. Add the following to the
 {{#include ../listings/ch19-advanced-features/listing-19-31/hello_macro/hello_macro_derive/Cargo.toml:7:12}}
 ```
 
-To start defining the procedural macro, place the code in Listing 19-31 into
-your *src/lib.rs* file for the `hello_macro_derive` crate. Note that this code
-won’t compile until we add a definition for the `impl_hello_macro` function.
+欲開始定義程序式巨集，請將範例 19-31 的程式碼放入你的 `hello_macro_derive` crate 的 *src.lib.rs* 檔案中。注意，在我們定義 `impl_hello_macro` 函式之前，這段程式碼都無法編譯。
 
 <span class="filename">檔案名稱：hello_macro_derive/src/lib.rs</span>
 
@@ -293,44 +162,20 @@ won’t compile until we add a definition for the `impl_hello_macro` function.
 {{#rustdoc_include ../listings/ch19-advanced-features/listing-19-31/hello_macro/hello_macro_derive/src/lib.rs}}
 ```
 
-<span class="caption">範例 19-31: Code that most procedural macro crates
-will require in order to process Rust code</span>
+<span class="caption">範例 19-31：若要產生 Rust 程式碼，絕大部分程序式巨集 crate 都必須包含這段程式碼</span>
 
-Notice that we’ve split the code into the `hello_macro_derive` function, which
-is responsible for parsing the `TokenStream`, and the `impl_hello_macro`
-function, which is responsible for transforming the syntax tree: this makes
-writing a procedural macro more convenient. The code in the outer function
-(`hello_macro_derive` in this case) will be the same for almost every
-procedural macro crate you see or create. The code you specify in the body of
-the inner function (`impl_hello_macro` in this case) will be different
-depending on your procedural macro’s purpose.
+留意到了嗎，我們將程式碼函式拆分，其中 `hello_macro_derive` 函式負責解析 `TokenStream`，而 `impl_hello_macro` 函式則用來轉換語法樹（syntax tree），這讓撰寫程序式巨集更為方便。外面這個函式的程式碼（在這例子是 `hello_macro_derive`）在每個你遇見或建立的程序式巨集裡看起來都幾乎一模一樣。而在裡面的函式（在這個例子是 `impl_hello_macro`）的本體則根據不同程序式巨集的目的而有所不同。
 
-We’ve introduced three new crates: `proc_macro`, [`syn`], and [`quote`]. The
-`proc_macro` crate comes with Rust, so we didn’t need to add that to the
-dependencies in *Cargo.toml*. The `proc_macro` crate is the compiler’s API that
-allows us to read and manipulate Rust code from our code.
+我們導入了三個新 crate：`proc_macro`，[`syn`] 和 [`quote`]。`proc_macro` 包含在 Rust 裡面，所以我們不需要將之加入 *Cargo.toml*。`proc_macro` crate 就是編譯器的 API，提供從我們的程式碼讀取和操作 Rust 程式碼。
 
 [`syn`]: https://crates.io/crates/syn
 [`quote`]: https://crates.io/crates/quote
 
-The `syn` crate parses Rust code from a string into a data structure that we
-can perform operations on. The `quote` crate turns `syn` data structures back
-into Rust code. These crates make it much simpler to parse any sort of Rust
-code we might want to handle: writing a full parser for Rust code is no simple
-task.
+`syn` crate 負責從字串解析 Rust 程式碼，轉成我們可以操作的資料結構。而 `qoute` crate 則將 `syn` 的資料結構轉回 Rust 程式碼。撰寫完整的Rust 程式碼解析器並不是容易的工作，而這些 crate 讓解析任何 Rust 程式碼更為簡便。
 
-The `hello_macro_derive` function will be called when a user of our library
-specifies `#[derive(HelloMacro)]` on a type. This is possible because we’ve
-annotated the `hello_macro_derive` function here with `proc_macro_derive` and
-specified the name, `HelloMacro`, which matches our trait name; this is the
-convention most procedural macros follow.
+當使用者在一個型別上指定 `#[derive(HelloMacro)]`，`hello_macro_derive` 函式就會被呼叫，這是由於我們使用 `proc_macro_derive` 和指定的 `HelloMacro` 名稱來標註 `hello_macro_derive` 函式，而其中的 `HelloMacro` 是我們的特徵名稱。以上就是大多數程序式巨集遵守的慣例。
 
-The `hello_macro_derive` function first converts the `input` from a
-`TokenStream` to a data structure that we can then interpret and perform
-operations on. This is where `syn` comes into play. The `parse` function in
-`syn` takes a `TokenStream` and returns a `DeriveInput` struct representing the
-parsed Rust code. Listing 19-32 shows the relevant parts of the `DeriveInput`
-struct we get from parsing the `struct Pancakes;` string:
+`hello_macro_derive` 函式會先將輸入 `input` 的 `TokenStream` 轉換成一個我們可以翻譯並執行操作的資料結構，這就是 `syn` 參與的部分，`syn` 的 `parse` 函式需要一個 `TokenStream` 並回傳一個 `DeriveInput` 結構體，代表解析過後的 Rust 程式碼。範例 19-32 展示了解析完 `struct Pancakes` 字串後所得的 `DeriveInput` 的部分：
 
 ```rust,ignore
 DeriveInput {
@@ -352,34 +197,18 @@ DeriveInput {
 }
 ```
 
-<span class="caption">範例 19-32: The `DeriveInput` instance we get when
-parsing the code that has the macro’s attribute in Listing 19-30</span>
+<span class="caption">範例 19-32：這是在範例 19-30 解析具有 macro 屬性的程式碼時所得的 `DeriveInput` 實例</span>
 
-The fields of this struct show that the Rust code we’ve parsed is a unit struct
-with the `ident` (identifier, meaning the name) of `Pancakes`. There are more
-fields on this struct for describing all sorts of Rust code; check the [`syn`
-documentation for `DeriveInput`][syn-docs] for more information.
+這些結構體的欄位展示了解析過後的 Rust 程式碼是一個結構體，帶著 `ident`（識別字 identifier）。這裡其他結構體的欄位都在描述 Rust 程式碼，更多資訊請參考 [`syn` 有關 `DeriveInput` 的文件][syn-docs]。
 
 [syn-docs]: https://docs.rs/syn/1.0/syn/struct.DeriveInput.html
 
-Soon we’ll define the `impl_hello_macro` function, which is where we’ll build
-the new Rust code we want to include. But before we do, note that the output
-for our derive macro is also a `TokenStream`. The returned `TokenStream` is
-added to the code that our crate users write, so when they compile their crate,
-they’ll get the extra functionality that we provide in the modified
-`TokenStream`.
 
-You might have noticed that we’re calling `unwrap` to cause the
-`hello_macro_derive` function to panic if the call to the `syn::parse` function
-fails here. It’s necessary for our procedural macro to panic on errors because
-`proc_macro_derive` functions must return `TokenStream` rather than `Result` to
-conform to the procedural macro API. We’ve simplified this example by using
-`unwrap`; in production code, you should provide more specific error messages
-about what went wrong by using `panic!` or `expect`.
+我們很快就進入定義 `impl_hello_macro` 函式的環節，這個函式協助打造我們想要的新 Rust 程式碼。再動手做之前，注意我們的 derive 巨集輸出也是一個 `TokenStream`。回傳的 `TokenStream` 會添加到我們的 crate 使用者撰寫的程式碼中，因此，當他們編譯他們的 crate 時，會從我們提供的修編過的 `TokenStream` 中取得額外功能。
 
-Now that we have the code to turn the annotated Rust code from a `TokenStream`
-into a `DeriveInput` instance, let’s generate the code that implements the
-`HelloMacro` trait on the annotated type, as shown in Listing 19-33.
+也許你注意到我們對 `hello_macro_derive` 呼叫 `unwrap` 讓 `sync::parse` 函式失敗時恐慌。由於我們需要符合 `proc_macro_derive` 程序式巨集的 API 定 義，回傳一個 `TokenStream` 而非 `Result`，所以我們的程序式巨集必須在錯誤時恐慌。這裡使用 `unwrap` 是為了簡化範例，在正式環境程式碼中，你應該透過 `panic!` 或 `expect` 提供更特定的錯誤訊息，告知什麼出錯了。
+
+現在，被標註的 Rust 程式碼已經從一個 `TokenStream` 轉換成 `DeriveInput` 實例，現在來替被標註的型別產生實作 `HelloMacro` 特徵的程式碼，如範例 19-33。
 
 <span class="filename">檔案名稱：hello_macro_derive/src/lib.rs</span>
 
@@ -387,136 +216,77 @@ into a `DeriveInput` instance, let’s generate the code that implements the
 {{#rustdoc_include ../listings/ch19-advanced-features/listing-19-33/hello_macro/hello_macro_derive/src/lib.rs:here}}
 ```
 
-<span class="caption">範例 19-33: Implementing the `HelloMacro` trait using
-the parsed Rust code</span>
+<span class="caption">範例 19-33：利用解析過的 Rust 程式碼來實作 `HelloMacro` 特徵</span>
 
-We get an `Ident` struct instance containing the name (identifier) of the
-annotated type using `ast.ident`. The struct in Listing 19-32 shows that when
-we run the `impl_hello_macro` function on the code in Listing 19-30, the
-`ident` we get will have the `ident` field with a value of `"Pancakes"`. Thus,
-the `name` variable in Listing 19-33 will contain an `Ident` struct instance
-that, when printed, will be the string `"Pancakes"`, the name of the struct in
-Listing 19-30.
+我們從 `ast.ident` 取得 `Ident` 結構體實例，這個實例中帶有被標註的型別之名稱（識別字）。當我們執行在範例 19-30 程式碼中的 `impl_hello_macro` 函式，會獲得一個 `ident`，帶有一個值為 `"Pancakes"` 的 `ident` 欄位，就如同範例 19-30 所示。因此，在範例 19-33 的 `name` 變數會包含一個 `Ident` 結構體實例，當我們印之，會出現字串 `"Pancakes"`，也就是該結構體在範例 19-30 所示的名字。
 
-The `quote!` macro lets us define the Rust code that we want to return. The
-compiler expects something different to the direct result of the `quote!`
-macro’s execution, so we need to convert it to a `TokenStream`. We do this by
-calling the `into` method, which consumes this intermediate representation and
-returns a value of the required `TokenStream` type.
+`quote!` 巨集提供我們定義想要回傳的 Rust 程式碼。編譯器期望接收到不同於 `quote!` 巨集執行後直接輸出的結果，所以我們需要將結果轉換為一個 `TokenStream`。我們透過呼叫 `into` 方法達成，這個方法會消耗中介碼（intermediate representation）並回傳一個型別為 `TokenStream` 之值。
 
-The `quote!` macro also provides some very cool templating mechanics: we can
-enter `#name`, and `quote!` will replace it with the value in the variable
-`name`. You can even do some repetition similar to the way regular macros work.
-Check out [the `quote` crate’s docs][quote-docs] for a thorough introduction.
+`quote!` 巨集也提供非常炫的模板機制：我們可以輸入 `#name`，而 `quote!` 會以變數 `name` 值取而代之。我們甚至可以做一些類似普通巨集的重複工作。閱讀 [`quote` crate 的文件][quote-docs]以獲得完整的介紹。
 
 [quote-docs]: https://docs.rs/quote
 
-We want our procedural macro to generate an implementation of our `HelloMacro`
-trait for the type the user annotated, which we can get by using `#name`. The
-trait implementation has one function, `hello_macro`, whose body contains the
-functionality we want to provide: printing `Hello, Macro! My name is` and then
-the name of the annotated type.
+我們想要我們的程序式巨集對使用者標註的型別產生 `HelloMacro` 特徵的實作，這個標註的型別名稱可以從 `#name` 取得。這個特徵的實作有一個函式 `hello_macro`，函式本體包含我們想要的功能：印出 `你好，巨集，我叫作` 再加上被標註的型別的名稱。
 
-The `stringify!` macro used here is built into Rust. It takes a Rust
-expression, such as `1 + 2`, and at compile time turns the expression into a
-string literal, such as `"1 + 2"`. This is different than `format!` or
-`println!`, macros which evaluate the expression and then turn the result into
-a `String`. There is a possibility that the `#name` input might be an
-expression to print literally, so we use `stringify!`. Using `stringify!` also
-saves an allocation by converting `#name` to a string literal at compile time.
+`stringify!` 巨集是 Rust 內建的，會將一個 Rust 表達式，例如 `1 + 2`，在編譯期轉換成字串字面值（string literal），例如 `"1 + 2"`。這和 `format!` 或 `println!` 巨集會對表達式求值並將結果轉為 `String` 不同。因為輸入的 `#name` 可能是一個表達式，但要直接照字面印出來，所以我們選擇使用 `stringify!`。使用 `stringify!` 也可以節省在編譯器因為轉換 `#name` 成為字串字面量所需的空間配置。
 
-At this point, `cargo build` should complete successfully in both `hello_macro`
-and `hello_macro_derive`. Let’s hook up these crates to the code in Listing
-19-30 to see the procedural macro in action! Create a new binary project in
-your *projects* directory using `cargo new pancakes`. We need to add
-`hello_macro` and `hello_macro_derive` as dependencies in the `pancakes`
-crate’s *Cargo.toml*. If you’re publishing your versions of `hello_macro` and
-`hello_macro_derive` to [crates.io](https://crates.io/), they would be regular
-dependencies; if not, you can specify them as `path` dependencies as follows:
+至此，`cargo build` 應該可以成功在 `hello_macro` 和 `hello_macro_derive` 完成。我們在範例 19-30 來玩玩這些 crate 看看他們如何實際作用！先在你的**專案**目錄下，透過 `cargo new pancakes` 建立一個新的二進制專案。我們必須將 `hello_macro` 和 `hello_macro_derive` 加入 `pancakes` 的 *Cargo.toml* 作為依賴。若你已經發佈自己的 `hello_macro` 和 `hello_macro_derive` 的版本到 [crates.io](https://crates.io/)，他們就是普通的依賴；若無，你可以指定他們為 `path` 的依賴，如下：
 
 ```toml
 {{#include ../listings/ch19-advanced-features/no-listing-21-pancakes/pancakes/Cargo.toml:7:9}}
 ```
 
-Put the code in Listing 19-30 into *src/main.rs*, and run `cargo run`: it
-should print `Hello, Macro! My name is Pancakes!` The implementation of the
-`HelloMacro` trait from the procedural macro was included without the
-`pancakes` crate needing to implement it; the `#[derive(HelloMacro)]` added the
-trait implementation.
+將這段程式碼放到範例 19-30 的 *src/main.rs* 並執行 `cargo run`，他應該會印出 `你好，巨集！我叫作鬆餅！`。這個由程序式巨集實作的 `HelloMacro` 特徵，不需要 `pancakes` 自行手動實作，而是透過 `#[derive(HelloMacro)]` 將特徵的實作加上去。
 
-Next, let’s explore how the other kinds of procedural macros differ from custom
-derive macros.
+接著，一起來探索其他種類的程序式巨集和客製化 derive 巨集有何不同。
 
-### Attribute-like macros
+### 類屬性巨集
 
-Attribute-like macros are similar to custom derive macros, but instead of
-generating code for the `derive` attribute, they allow you to create new
-attributes. They’re also more flexible: `derive` only works for structs and
-enums; attributes can be applied to other items as well, such as functions.
-Here’s an example of using an attribute-like macro: say you have an attribute
-named `route` that annotates functions when using a web application framework:
+類屬性巨集和客製化 derive 巨集相似，但並非只能透過 `derive` 屬性產生程式碼，類屬性巨集讓你可以建立新的屬性。它們更靈活：`derive` 只能用在結構體和枚舉，而屬性可以用在其他項目之上，例如函式。這裡有個類屬性巨集例子，是在使用一個網頁應用程式框架時，透過你的 `route` 屬性來標註一個函式：
 
 ```rust,ignore
 #[route(GET, "/")]
 fn index() {
 ```
 
-This `#[route]` attribute would be defined by the framework as a procedural
-macro. The signature of the macro definition function would look like this:
+這個 `#[route]` 屬性在該框架以程序式巨集定義之，其巨集定義函式的簽名如下：
 
 ```rust,ignore
 #[proc_macro_attribute]
 pub fn route(attr: TokenStream, item: TokenStream) -> TokenStream {
 ```
 
-Here, we have two parameters of type `TokenStream`. The first is for the
-contents of the attribute: the `GET, "/"` part. The second is the body of the
-item the attribute is attached to: in this case, `fn index() {}` and the rest
-of the function’s body.
+這裡，我們有兩個 `TokenStream` 型別的參數，第一個是屬性的內容，也就是 `Get, "/"` 這部分。第二部分則是該屬性附著的項目本體：在這個例子就是 `fn index() {}` 及其函式本體。
 
-Other than that, attribute-like macros work the same way as custom derive
-macros: you create a crate with the `proc-macro` crate type and implement a
-function that generates the code you want!
+除此之外，類屬性巨集的工作方式和客製化 derive 巨集一樣：透過 `proc-macro` crate 建立一個 crate，並實作一個函式替你產生程式碼！
 
-### Function-like macros
+### 類函式巨集
 
-Function-like macros define macros that look like function calls. Similarly to
-`macro_rules!` macros, they’re more flexible than functions; for example, they
-can take an unknown number of arguments. However, `macro_rules!` macros can be
-defined only using the match-like syntax we discussed in the section
-[“Declarative Macros with `macro_rules!` for General Metaprogramming”][decl]
-earlier. Function-like macros take a `TokenStream` parameter and their
-definition manipulates that `TokenStream` using Rust code as the other two
-types of procedural macros do. An example of a function-like macro is an `sql!`
-macro that might be called like so:
+類函式巨集可以定義和函式呼叫很類似的巨集。和 `marco_rules!` 一樣，類函式巨集比函式更有靈活，例如可以接收未知長度的引數。然而，`macro_rules!` 巨集只能使用像 match 一樣的語法，如同早前在[「使用 `macro_rules!` 宣告式巨集做普通的超程式設計」][宣告式巨集]一節所述。而類函式巨集則可以拿 `TokenStream` 參數及其定義來操作 Rust 程式碼，和另外兩個程序式巨集所做的一模一樣。
 
-[decl]: #declarative-macros-with-macro_rules-for-general-metaprogramming
+舉個例子，一個 `sql!` 類函式巨集可能會被這樣呼叫：
+
+[宣告式巨集]: #使用-macro_rules-宣告式巨集做普通的超程式設計
 
 ```rust,ignore
 let sql = sql!(SELECT * FROM posts WHERE id=1);
 ```
 
-This macro would parse the SQL statement inside it and check that it’s
-syntactically correct, which is much more complex processing than a
-`macro_rules!` macro can do. The `sql!` macro would be defined like this:
+這個巨集會解析他內部的 SQL 陳述句（statement），並檢查語法是否正確，這個過程比 `macro_rules!` 能做到的複雜太多。這個 `sql!` 巨集定義如下：
 
 ```rust,ignore
 #[proc_macro]
 pub fn sql(input: TokenStream) -> TokenStream {
 ```
 
-This definition is similar to the custom derive macro’s signature: we receive
-the tokens that are inside the parentheses and return the code we wanted to
-generate.
+這個定義和客製化 derive 巨集簽名相似：我們接受在圓括號內的標記，並回傳想要產生的程式碼。
 
-## Summary
+## 小結
 
-Whew! Now you have some Rust features in your toolbox that you won’t use often,
-but you’ll know they’re available in very particular circumstances. We’ve
-introduced several complex topics so that when you encounter them in error
-message suggestions or in other peoples’ code, you’ll be able to recognize
-these concepts and syntax. Use this chapter as a reference to guide you to
-solutions.
+太帥了！現在你的工具箱多了一些 Rust 特色功能，雖然不常用，但在特定情況下你會知道它們存在。我們介紹了許多複雜的主題，所以當你在錯誤訊息或是其他人的程式碼與它們相遇，你會有辦法辨認這些概念和語法。你可以將這章作為能引導找到解法的參考書。
 
-Next, we’ll put everything we’ve discussed throughout the book into practice
-and do one more project!
+接下來，我們會動手做另一個專案，實際運用本書所講的一切。
+
+> - translators: [Weihang Lo <me@weihanglo.tw>]
+> - commit: [d44317c](https://github.com/rust-lang/book/blob/d44317c3122b44fb713aba66cc295dee3453b24b/src/ch19-06-macros.md)
+> - updated: 2020-09-20


### PR DESCRIPTION
[Rendered](https://github.com/rust-tw/book-tw/blob/6fd36d74206b3669be6f98d8d3c4ace987a81d7e/src/ch19-06-macros.md)

本章的專有名詞對照表，若有異議，歡迎提出，

| 原文 | 中文 | 理由 |
| ------- | -------- | ------- |
| annotation | 標註 | |
| attribute | 屬性 | |
| attribute-like macros | 類屬性巨集 | |
| binary project | 二進制專案 | |
| declarative macros | 宣告式巨集 | |
| dependency | 依賴 | |
| edge case | 邊界情況 | |
| function-like macros | 類函式巨集 | |
| identifier | 識別字 | |
| intermediate representation | 中介碼 | |
| item | 項目 | |
| macro | 巨集 | |
| macros by example | 巨集為例 | |
| metaprogramming | 超程式設計 | |
| procedural macros | 程序式巨集 | |
| re-export | 重新導出 | |
| reflection | 反射 | |
| scope | 作用域 | |
| statement | 陳述句 | |
| string literal | 字串字面值 | |
| syntax tree | 語法樹 | |
| token | 標記 | |
