### PR TITLE
Set language to "zh"

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,6 +1,7 @@
 [book]
 title = "Rust 程式設計語言"
 author = "Steve Klabnik and Carol Nichols, with Contributions from the Rust Community"
+language = "zh"
 
 [output.html]
 additional-css = ["ferris.css", "theme/2018-edition.css"]


### PR DESCRIPTION
So that browsers can choose the correct default fonts base on the html lang attribute.

Currently the html looks like

```html
<html lang="en" class="sidebar-visible no-js light">
```

New output

```html
<html lang="zh" class="sidebar-visible no-js light">
```