### PR TITLE
修正14.2節Sync的中文翻譯

### DIFF
--- a/src/ch14-02-publishing-to-crates-io.md
+++ b/src/ch14-02-publishing-to-crates-io.md
@@ -55,7 +55,7 @@ test src/lib.rs - add_one (line 5) ... ok
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.27s
 ```
 
-現在如果我們變更函式或範例使其內的 `assert_eq!` 會恐慌並再次執行 `cargo test` 的話，我們會看到技術文件測試能互相獲取錯誤，告訴我們範例與程式碼已經不同不了！
+現在如果我們變更函式或範例使其內的 `assert_eq!` 會恐慌並再次執行 `cargo test` 的話，我們會看到技術文件測試能互相獲取錯誤，告訴我們範例與程式碼已經不同步了！
 
 #### 包含項目結構的註解
 


### PR DESCRIPTION
修正Sync的翻譯，由**同不**修正為**同步** (見14.2節子標題"**將技術文件註解作為測試**"之下)

[英文原文](https://doc.rust-lang.org/book/ch14-02-publishing-to-crates-io.html):
Now if we change either the function or the example so the assert_eq! in the example panics and run cargo test again, we’ll see that the doc tests catch that the example and the code are out of **sync** with each other!

[正體中文](https://rust-lang.tw/book-tw/ch14-02-publishing-to-crates-io.html):
現在如果我們變更函式或範例使其內的 assert_eq! 會恐慌並再次執行 cargo test 的話，我們會看到技術文件測試能互相獲取錯誤，告訴我們範例與程式碼已經不**同不**了！