### PR TITLE
docs: correct arguments of command line

### DIFF
--- a/listings/ch12-an-io-project/listing-12-02/output.txt
+++ b/listings/ch12-an-io-project/listing-12-02/output.txt
@@ -1,4 +1,4 @@
-$ cargo run test -- sample.txt
+$ cargo run -- test sample.txt
    Compiling minigrep v0.1.0 (file:///projects/minigrep)
     Finished dev [unoptimized + debuginfo] target(s) in 0.0s
      Running `target/debug/minigrep test sample.txt`


### PR DESCRIPTION
Correct arguments of command line in `/listings/ch12-an-io-project/listing-12-02/output.txt`.