### PR TITLE
first_word function also works for whole String reference

### DIFF
--- a/listings/ch04-understanding-ownership/listing-04-09/src/main.rs
+++ b/listings/ch04-understanding-ownership/listing-04-09/src/main.rs
@@ -19,6 +19,8 @@ fn main() {
     // first_word 適用於 `String` 的切片，無論是部分或整體
     let word = first_word(&my_string[0..6]);
     let word = first_word(&my_string[..]);
+    // first_word 也適用於 `String` 的參考，這等同於對整個 `String` 切片的操作。
+    let word = first_word(&my_string);
 
     let my_string_literal = "hello world";
 


### PR DESCRIPTION
ref: https://doc.rust-lang.org/stable/book/ch04-03-slices.html?highlight=slice#string-slices-as-parameters

```rust
fn main() {
    let my_string = String::from("hello world");

    // `first_word` works on slices of `String`s, whether partial or whole
    let word = first_word(&my_string[0..6]);
    let word = first_word(&my_string[..]);
    // `first_word` also works on references to `String`s, which are equivalent
    // to whole slices of `String`s
    let word = first_word(&my_string);

    let my_string_literal = "hello world";

    // `first_word` works on slices of string literals, whether partial or whole
    let word = first_word(&my_string_literal[0..6]);
    let word = first_word(&my_string_literal[..]);

    // Because string literals *are* string slices already,
    // this works too, without the slice syntax!
    let word = first_word(my_string_literal);
}
```