### PR TITLE
fix: translation in ch14-03-cargo-workspaces

### DIFF
--- a/src/ch14-03-cargo-workspaces.md
+++ b/src/ch14-03-cargo-workspaces.md
@@ -209,7 +209,7 @@ error[E0432]: unresolved import `rand`
   |     ^^^^ no external crate `rand`
 ```
 
-要修正此問題，只要修改 `adder` 套件的 *Cargo.toml* 檔案，指示它也加入 `rand` 作為依賴就好了。這樣建構 `adder` 套件就會將在 *Cargo.lock* 中將 `rand` 加入 `adder` 的依賴，但是沒有額外的 `rand` 會被下載。Cargo 會確保工作空間中每個套件的每個 crate 都會使用相同的 `rand` 套件版本。這可以節省空間，並能確保工作空間中的 crate 彼此可以互相兼容。
+要修正此問題，只要修改 `adder` 套件的 *Cargo.toml* 檔案，指示它也加入 `rand` 作為依賴就好了。這樣建構 `adder` 套件就會將在 *Cargo.lock* 中將 `rand` 加入 `adder` 的依賴，但是沒有額外的 `rand` 會被下載。Cargo 會確保工作空間中每個套件的每個 crate 都會使用相同的 `rand` 套件版本。這可以節省空間，並能確保工作空間中的 crate 彼此相容。
 
 #### 在工作空間中新增測試
 


### PR DESCRIPTION
資訊領域中，「相容」（臺灣）與「兼容」（中國）的部分不用說，原本的翻譯也有贅字，故一併改善。